### PR TITLE
fix: typescript compile issue

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,4 +1,3 @@
-import * as fs from 'fs';
 import * as glob from 'glob';
 import * as path from 'path';
 import * as ts from 'typescript';
@@ -20,9 +19,9 @@ function transform(filePath: string) {
   const compilerOptions: ts.CompilerOptions = {};
   const fileNames = findFiles(filePath);
   const program = ts.createProgram(fileNames, compilerOptions);
-  const typeChecker = program.getTypeChecker();
+  const typeChecker = program.getTypeChecker(); // XXX unused var
   const sourceFiles = program.getSourceFiles();
-  const interfaces = new Set();
+  const interfaces = new Set<string>();
 
   log("Found SoureceFiles", fileNames);
   log("Starting generation an", program.getCurrentDirectory())


### PR DESCRIPTION
Otherwise you get this error (ts 3.9.x)

```
src/ts-interface-to-gql/transform.ts:33:44 - error TS2345: Argument of type 'Set<unknown>' is not assignable to parameter of type 'Set<string>'.
  Type 'unknown' is not assignable to type 'string'.

33         schemas += parse(sourceFile, node, interfaces);
```